### PR TITLE
Set Image First on Mobile Release

### DIFF
--- a/components/blocks/IllustrationContent.js
+++ b/components/blocks/IllustrationContent.js
@@ -15,7 +15,8 @@ const IllustrationContent = ({ blok, position }) => {
         contentId,
         _uid,
         component,
-        anchorIdentity
+        anchorIdentity,
+        setImageFirstMobile
     } = blok;
 
     let imageSize = dimensions(image.filename);
@@ -25,7 +26,7 @@ const IllustrationContent = ({ blok, position }) => {
         <section id={contentId ? contentId : anchorIdentity ? anchorIdentity : _uid} data-name={component} className={`${background} py-24`}>
             <Container>
                 <div className="mx-auto grid max-w-2xl grid-cols-1 gap-x-8 gap-y-16 sm:gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-2">
-                    <div className="grid lg:grid-cols-[auto,1fr]">
+                    <div className={`${setImageFirstMobile ? "order-1" : "order-2"} sm:order-1 grid lg:grid-cols-[auto,1fr]`}>
                         <div>
                             {illustrations && (
                                 <div className="flex flex-row justify-around mb-4 lg:justify-center lg:flex-col space-y-2">
@@ -51,7 +52,7 @@ const IllustrationContent = ({ blok, position }) => {
                             )}
                         </div>
                     </div>
-                    <div className="lg:pl-4 lg:pt-4">
+                    <div className={`${setImageFirstMobile ? "order-2" : "order-1"} sm:order-2 lg:pl-4 lg:pt-4`}>
                         <div className="lg:max-w-lg">
                             {heading && <h2 className="text-2xl sm:text-4xl font-glacialBold font-semibold leading-7 mb-6">{heading}</h2>}
                             {render(description, {

--- a/components/blocks/Newsletter.js
+++ b/components/blocks/Newsletter.js
@@ -43,7 +43,7 @@ const Newsletter = ({ className, bgColor }) => {
     };
 
     return (
-        <div className={`mb-2 w-full max-w-[320px] mx-auto ${className}`}>
+        <div className={`mb-2 w-full max-w-[320px] mx-auto ${className ? className : ""}`}>
             <form onSubmit={handleSubmit}>
                 <label htmlFor="email" className="sr-only block text-sm font-medium font-glacialRegular leading-6 text-gray-900">
                     Email address

--- a/components/blocks/Wayfinder.js
+++ b/components/blocks/Wayfinder.js
@@ -20,7 +20,8 @@ const Wayfinder = ({blok, position}) => {
         image,
         _uid,
         component,
-        anchorIdentity
+        anchorIdentity,
+        setImageFirstMobile
     } = blok;
 
     let imageBelowTextSize = {};
@@ -33,7 +34,7 @@ const Wayfinder = ({blok, position}) => {
         <section className={`overflow-hidden ${sectionPadding === 'none' ? "py-0" : sectionPadding === 'small' ? "py-4 sm:py-8 md:py-12" : "py-12 smpy-24 md:py-32"} ${background}`} id={contentId ? contentId : anchorIdentity ? anchorIdentity : _uid} data-name={component}>
             <Container>
                 <div className="mx-auto grid max-w-2xl grid-cols-1 gap-x-8 gap-y-16 sm:gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-2">
-                    <div className={`${setImageFirst ? "sm:order-2 lg:pl-4 lg:pt-4" : "sm:order-1 lg:pr-4 lg:pt-4"}`}>
+                    <div className={`${setImageFirstMobile ? "order-2" : "order-1"} ${setImageFirst ? "sm:order-2 lg:pl-4 lg:pt-4" : "sm:order-1 lg:pr-4 lg:pt-4"}`}>
                         <div className="lg:max-w-lg">
                             {heading && <h2 className="text-2xl sm:text-4xl font-glacialBold font-semibold leading-7 mb-6">{heading}</h2>}
                             {description && <RichText story={description} className="mt-6 text-lg leading-8 text-gray-600" /> }
@@ -47,7 +48,7 @@ const Wayfinder = ({blok, position}) => {
                             )}
                         </div>
                     </div>
-                    <div className={`flex items-start ${setImageFirst ? "sm:order-1 justify-end" : "justify-start sm:order-2"}`}>
+                    <div className={`flex items-start ${setImageFirstMobile ? "order-1" : "order-2" } ${setImageFirst ? "sm:order-1 justify-end" : "justify-start sm:order-2"}`}>
                         <ImageRef image={image} width={600} height={600} className="w-full sm:w-[48rem] max-w-none md:w-[57rem]" />
                     </div>
                 </div>


### PR DESCRIPTION
In the wayfinder and illustrator component i have added the value setImageFirstMobile in display tab. which on mobile as it says will set the image first before the text content.

<img width="1092" alt="Screenshot 2025-01-15 at 21 50 36" src="https://github.com/user-attachments/assets/405cb314-7c7b-4a2e-8f4d-e5704ea3f7d9" />
