### PR TITLE
update react-player issues to fix player and videos not loading

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -53,16 +53,17 @@ export default async function RootLayout({ children }) {
 
       <html lang="en" className="w-screen">
         <head>
-          <script
+          <Script
             id="mcjs"
+            strategy="afterInteractive"
             dangerouslySetInnerHTML={{
               __html: `!function(c,h,i,m,p){
-                m=c.createElement(h),
-                p=c.getElementsByTagName(h)[0],
-                m.async=1,
-                m.src=i,
-                p.parentNode.insertBefore(m,p)
-              }(document,"script","https://chimpstatic.com/mcjs-connected/js/users/57d0c9b60c47da3fb219b36cd/7ea86ea1a0f0b85649fc5b2c8.js");`,
+        m=c.createElement(h),
+        p=c.getElementsByTagName(h)[0],
+        m.async=1,
+        m.src=i,
+        p.parentNode.insertBefore(m,p)
+      }(document,"script","https://chimpstatic.com/mcjs-connected/js/users/57d0c9b60c47da3fb219b36cd/7ea86ea1a0f0b85649fc5b2c8.js");`,
             }}
           />
         </head>

--- a/components/blocks/VideoCard.js
+++ b/components/blocks/VideoCard.js
@@ -7,10 +7,11 @@ const VideoCard = ({ video }) => {
         videoURL,
         anchorIdentity
     } = video;
+
     return (
         <>
             <div id={anchorIdentity ? anchorIdentity : _uid} data-component="video-card" className="my-12">
-                <YouTubePlayer videoId={videoURL} videoTitle={videoTitle} />
+                <YouTubePlayer videoUrl={videoURL} videoTitle={videoTitle} />
             </div>
         </>
     )

--- a/components/global/youtubeEmbed.js
+++ b/components/global/youtubeEmbed.js
@@ -1,24 +1,54 @@
 'use client'
-import React, { useRef } from 'react';
+import React, { useRef, useMemo } from 'react';
 import ReactPlayer from 'react-player';
 import screenfull from 'screenfull'
 import { ArrowsPointingOutIcon } from '@heroicons/react/24/outline'
 
-const VideoComponent = ({ videoId, videoTitle }) => {
+const VideoComponent = ({ videoUrl, videoTitle }) => {
     const player = useRef(null);
+    const containerRef = useRef(null);
 
     const handleClickFullscreen = () => {
-        if (screenfull.isEnabled) {
-            screenfull.request(player.current.wrapper);
+        if (screenfull.isEnabled && containerRef.current) {
+            screenfull.request(containerRef.current);
         }
     };
 
+    const processedVideoUrl = useMemo(() => {
+        if (!videoUrl) return videoUrl;
+
+        try {
+            const url = new URL(videoUrl);
+            const params = url.searchParams;
+
+            // Check and add modestbranding if missing
+            if (!params.has('modestbranding')) {
+                params.set('modestbranding', '1');
+            }
+
+            // Check and add playsinline if missing
+            if (!params.has('playsinline')) {
+                params.set('playsinline', '1');
+            }
+
+            return url.toString();
+        } catch (error) {
+            // If URL parsing fails, return original
+            console.error('Invalid video URL:', error);
+            return videoUrl;
+        }
+    }, [videoUrl]);
+
     return (
         <>
-            <div className="mb-1" style={{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', maxWidth: '100%' }}>
+            <div 
+                ref={containerRef}
+                className="mb-1" 
+                style={{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', maxWidth: '100%' }}
+            >
                 <ReactPlayer
                     ref={player}
-                    url={`https://www.youtube.com/watch?fs=0&modestbranding=1&playsinline=1&rel=0&v=${videoId}`}
+                    src={processedVideoUrl}
                     width="100%"
                     height="100%"
                     style={{ position: 'absolute', top: 0, left: 0 }}
@@ -39,4 +69,3 @@ const VideoComponent = ({ videoId, videoTitle }) => {
 };
 
 export default VideoComponent;
-

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,15 +1,18 @@
 /** @type {import('next').NextConfig} */
+
+
 const nextConfig = {
-    images: {
-        remotePatterns: [
-          {
-            protocol: 'https',
-            hostname: 'a.storyblok.com',
-            port: '',
-          }
-        ],
-        deviceSizes: [640, 750, 768, 850, 1080, 1200, 1920, 2048, 3840],
-    },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'a.storyblok.com',
+        port: '',
+      }
+    ],
+    deviceSizes: [640, 750, 768, 850, 1080, 1200, 1920, 2048, 3840],
+  },
 };
+
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.53.0",
-    "react-player": "^3.3.3",
+    "react-player": "^3.4.0",
     "react-social-icons": "^6.18.0",
     "screenfull": "^6.0.2",
     "sitemap": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -167,42 +167,42 @@
   dependencies:
     mux-embed "5.9.0"
 
-"@mux/mux-player-react@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@mux/mux-player-react/-/mux-player-react-3.6.0.tgz#c69d09016f8cd68ea3016bf5d53bd1d718483f59"
-  integrity sha512-bh2Z1fQqNkKCNUMS/3VU6jL2iY22155ZSIyizfz+bVX0EYHqdsS/iG95iDYLPlzA8WPyIh+J210tme68e1qP+w==
+"@mux/mux-player-react@^3.8.0":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@mux/mux-player-react/-/mux-player-react-3.10.2.tgz#3daec996ad31c5a74da6ee67a11fe725f3f250aa"
+  integrity sha512-Grg9us93llxESHAPDxWZJKZiknTi0AtpqPLuyiqiLc7DYcJkgnUHG8pSHQ8i7A/gKC5tOhCyCoKm3p2Ei8vIrQ==
   dependencies:
-    "@mux/mux-player" "3.6.0"
-    "@mux/playback-core" "0.31.0"
+    "@mux/mux-player" "3.10.2"
+    "@mux/playback-core" "0.32.2"
     prop-types "^15.8.1"
 
-"@mux/mux-player@3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@mux/mux-player/-/mux-player-3.6.0.tgz#64e66522449b3d919dddb8cf5ff46b5f73a7c538"
-  integrity sha512-yVWmTMJUoKNZZxsINFmz7ZUUR3GC+Qf7b6Qv2GTmUoYn14pO1aXywHLlMLDohstLIvdeOdh6F/WsD2/gDVSOmQ==
+"@mux/mux-player@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@mux/mux-player/-/mux-player-3.10.2.tgz#75c7dad395c0a64afef3bd6b4faeac1babfa0a4d"
+  integrity sha512-iLFOCUgIqXum7bErn2cPb+f/DHCXC8i2rbFl6+SIf6r/oHRp0djkoLaeaX30hsA/SUdCLQze7oL4IM2QHRmONg==
   dependencies:
-    "@mux/mux-video" "0.27.0"
-    "@mux/playback-core" "0.31.0"
-    media-chrome "~4.13.1"
-    player.style "^0.2.0"
+    "@mux/mux-video" "0.29.2"
+    "@mux/playback-core" "0.32.2"
+    media-chrome "~4.17.2"
+    player.style "^0.3.0"
 
-"@mux/mux-video@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@mux/mux-video/-/mux-video-0.27.0.tgz#66dc37af9c296389d47ea15e470c47c869a71fe5"
-  integrity sha512-Oi142YAcPKrmHTG+eaWHWaE7ucMHeJwx1FXABbLM2hMGj9MQ7kYjsD5J3meFlvuyz5UeVDsPLHeUJgeBXUZovg==
+"@mux/mux-video@0.29.2":
+  version "0.29.2"
+  resolved "https://registry.yarnpkg.com/@mux/mux-video/-/mux-video-0.29.2.tgz#68cbf78f63f2a8a8b9ceef40257c639a799c6cc2"
+  integrity sha512-qKnbMoPI50oJnH89d8UJjWPx6yrtyAmm6wysr1biZI561f257b7P8VE8fnXb9Ak1Gs3rBiNLiw/vCXwBdCkl+A==
   dependencies:
     "@mux/mux-data-google-ima" "0.2.8"
-    "@mux/playback-core" "0.31.0"
-    castable-video "~1.1.10"
+    "@mux/playback-core" "0.32.2"
+    castable-video "~1.1.11"
     custom-media-element "~1.4.5"
-    media-tracks "~0.3.3"
+    media-tracks "~0.3.4"
 
-"@mux/playback-core@0.31.0":
-  version "0.31.0"
-  resolved "https://registry.yarnpkg.com/@mux/playback-core/-/playback-core-0.31.0.tgz#cbe83aceaebe89fd835601bd1e83d19239fc8f15"
-  integrity sha512-VADcrtS4O6fQBH8qmgavS6h7v7amzy2oCguu1NnLaVZ3Z8WccNXcF0s7jPRoRDyXWGShgtVhypW2uXjLpkPxyw==
+"@mux/playback-core@0.32.2":
+  version "0.32.2"
+  resolved "https://registry.yarnpkg.com/@mux/playback-core/-/playback-core-0.32.2.tgz#dd714b8dc165118ce10af83f3fa563fafa7b8e86"
+  integrity sha512-cmaZN0hRIrEFcSVsj+quBDOeztg5oxug02WwuAiweWkMt1vSBM8nlzuF03coRnD/sKhgnQawdJOrng42R8I0Cg==
   dependencies:
-    hls.js "~1.6.6"
+    hls.js "~1.6.15"
     mux-embed "^5.8.3"
 
 "@next/env@14.2.13":
@@ -829,17 +829,17 @@ caniuse-lite@^1.0.30001579:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001662.tgz#3574b22dfec54a3f3b6787331da1040fe8e763ec"
   integrity sha512-sgMUVwLmGseH8ZIrm1d51UbrhqMCH3jvS7gF/M6byuHOnKyLOBL7W8yz5V02OHwgLGA36o/AFhWzzh4uc5aqTA==
 
-castable-video@~1.1.10:
+castable-video@~1.1.11:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/castable-video/-/castable-video-1.1.11.tgz#984b10c1ffe614b5851aa0b03430b0d92034dcd1"
   integrity sha512-LCRTK6oe7SB1SiUQFzZCo6D6gcEzijqBTVIuj3smKpQdesXM18QTbCVqWgh9MfOeQgTx/i9ji5jGcdqNPeWg2g==
   dependencies:
     custom-media-element "~1.4.5"
 
-ce-la-react@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/ce-la-react/-/ce-la-react-0.3.1.tgz#97f24f92317b8a2b654dbf9a29b05c2fcfaa2022"
-  integrity sha512-g0YwpZDPIwTwFumGTzNHcgJA6VhFfFCJkSNdUdC04br2UfU+56JDrJrJva3FZ7MToB4NDHAFBiPE/PZdNl1mQA==
+ce-la-react@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/ce-la-react/-/ce-la-react-0.3.2.tgz#66c1454e024c3b9f65ebac05724d0f50756ff057"
+  integrity sha512-QJ6k4lOD/btI08xG8jBPxRCGXvCnusGGkTsiXk0u3NqUu/W+BXRnFD4PYjwtqh8AWmGa5LDbGk0fLQsqr0nSMA==
 
 chalk@^4.0.0:
   version "4.1.2"
@@ -947,14 +947,14 @@ damerau-levenshtein@^1.0.8:
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
 
-dash-video-element@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/dash-video-element/-/dash-video-element-0.2.0.tgz#ce413529770dae91738c91d8064aba7f6ca034da"
-  integrity sha512-dgmhBOte6JgvSvowvrh0Q/vhSrB52Q/AUl/KqminAUkPuUT3CCUNhto1X8ANigWkmNwhktFc/PCe0lF/4tBFwQ==
+dash-video-element@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/dash-video-element/-/dash-video-element-0.3.1.tgz#e37a03b0b686eb5a0ef23a98a2439c37cc4f6142"
+  integrity sha512-KSdCd6lqjum4LizHLtB2EGvaGr7YJU7SZekTTDHixRondaRNcm0t9W2V3I7/itNBzQwdDbC1cKkXryc8I8IViA==
   dependencies:
     custom-media-element "^1.4.5"
     dashjs "^5.0.3"
-    media-tracks "^0.3.3"
+    media-tracks "^0.3.4"
 
 dashjs@^5.0.3:
   version "5.0.3"
@@ -1736,19 +1736,24 @@ hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
-hls-video-element@^1.5.8:
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/hls-video-element/-/hls-video-element-1.5.8.tgz#9b3ad1371d603a04b6d129a8aac5e3add7a41ede"
-  integrity sha512-DdeX5NzhM2Bj+ls5aaRrzSSnriK+r6lCrDa0YyfviNO4zb10JyAnJHZM214lXBWQghCm+fKmlWW1qpzdNoSAvQ==
+hls-video-element@^1.5.9:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/hls-video-element/-/hls-video-element-1.5.10.tgz#7fdad7bc3e0bcbab68f19e9aede5ef65cc11f3ee"
+  integrity sha512-FruzD03CaQlPlNKfXO1njPbo3jCSImAtFwX1OqgFbMllTQzdYqAHODiWan0q3mr1cYCONOWiAz2/nX+2qHHC+g==
   dependencies:
     custom-media-element "^1.4.5"
     hls.js "^1.6.5"
-    media-tracks "^0.3.3"
+    media-tracks "^0.3.4"
 
-hls.js@^1.6.5, hls.js@~1.6.6:
+hls.js@^1.6.5:
   version "1.6.13"
   resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.6.13.tgz#fcf2823f17aaf9127b9011ef135cae5d2520ab75"
   integrity sha512-hNEzjZNHf5bFrUNvdS4/1RjIanuJ6szpWNfTaX5I6WfGynWXGT7K/YQLYtemSvFExzeMdgdE4SsyVLJbd5PcZA==
+
+hls.js@~1.6.15:
+  version "1.6.15"
+  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.6.15.tgz#9ce13080d143a9bc9b903fb43f081e335b8321e5"
+  integrity sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==
 
 html-entities@^2.5.2:
   version "2.6.0"
@@ -2190,17 +2195,24 @@ lru-cache@^10.2.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
-media-chrome@~4.13.0, media-chrome@~4.13.1:
-  version "4.13.1"
-  resolved "https://registry.yarnpkg.com/media-chrome/-/media-chrome-4.13.1.tgz#adf71f7e64ee5facb60a04f508d85c2f334ec81e"
-  integrity sha512-jPPwYrFkM4ky27/xNYEeyRPOBC7qvru4Oydy7vQHMHplXLQJmjtcauhlLPvG0O5kkYFEaOBXv5zGYes/UxOoVw==
+media-chrome@~4.16.1:
+  version "4.16.1"
+  resolved "https://registry.yarnpkg.com/media-chrome/-/media-chrome-4.16.1.tgz#0ebaba9ac678329723cfcc5235db19f6a83a1a1a"
+  integrity sha512-qtFlsy0lNDVCyVo//ZCAfRPKwgehfOYp6rThZzDUuZ5ypv41yqUfAxK+P9TOs+XSVWXATPTT2WRV0fbW0BH4vQ==
   dependencies:
-    ce-la-react "^0.3.0"
+    ce-la-react "^0.3.2"
 
-media-tracks@^0.3.3, media-tracks@~0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/media-tracks/-/media-tracks-0.3.3.tgz#cca72bd791dcb76cd6427dfa6b2baa25601ea192"
-  integrity sha512-9P2FuUHnZZ3iji+2RQk7Zkh5AmZTnOG5fODACnjhCVveX1McY3jmCRHofIEI+yTBqplz7LXy48c7fQ3Uigp88w==
+media-chrome@~4.17.2:
+  version "4.17.2"
+  resolved "https://registry.yarnpkg.com/media-chrome/-/media-chrome-4.17.2.tgz#00830ea85ecb79b6c12bcf47c82c25ff1c04ed20"
+  integrity sha512-o/IgiHx0tdSVwRxxqF5H12FK31A/A8T71sv3KdAvh7b6XeBS9dXwqvIFwlR9kdEuqg3n7xpmRIuL83rmYq8FTg==
+  dependencies:
+    ce-la-react "^0.3.2"
+
+media-tracks@^0.3.4, media-tracks@~0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/media-tracks/-/media-tracks-0.3.4.tgz#8d078ba11fafa7bbdf07eb0583a2d60eed2279c7"
+  integrity sha512-5SUElzGMYXA7bcyZBL1YzLTxH9Iyw1AeYNJxzByqbestrrtB0F3wfiWUr7aROpwodO4fwnxOt78Xjb3o3ONNQg==
 
 merge2@^1.3.0:
   version "1.4.1"
@@ -2501,12 +2513,12 @@ pirates@^4.0.1:
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.6.tgz#3018ae32ecfcff6c29ba2267cbf21166ac1f36b9"
   integrity sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==
 
-player.style@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/player.style/-/player.style-0.2.0.tgz#2255a249525b9555822a3536048dcbf014637010"
-  integrity sha512-Ngoaz49TClptMr8HDA2IFmjT3Iq6R27QEUH/C+On33L59RSF3dCLefBYB1Au2RDZQJ6oVFpc1sXaPVpp7fEzzA==
+player.style@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/player.style/-/player.style-0.3.1.tgz#eb8c32c8f28c10bf84c692b20a1ea9efa1550709"
+  integrity sha512-z/T8hJGaTkHT9vdXgWdOgF37eB1FV7/j52VXQZ2lgEhpru9oT8TaUWIxp6GoxTnhPBM4X6nSbpkAHrT7UTjUKg==
   dependencies:
-    media-chrome "~4.13.0"
+    media-chrome "~4.16.1"
 
 possible-typed-array-names@^1.0.0:
   version "1.0.0"
@@ -2622,21 +2634,21 @@ react-is@^16.13.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-player@^3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/react-player/-/react-player-3.3.3.tgz#1200c28860213cf081e3845ace8727fa6c265e79"
-  integrity sha512-6U2ziVohA3WLdKI/WEQ7v27CIive0TCNIro55lJZka06fjB2kC4lJqBrvddG0yBvTDcn1owiUf2hRNaIzHAjIg==
+react-player@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/react-player/-/react-player-3.4.0.tgz#2d01f4833b52c221f0ae63e90770612edae71861"
+  integrity sha512-QpQSHXtnMBKjQVNeaCYMtTVcynWQ0DDDhz/FJu1OR9PHLC1Aih94UqNstywzSHbJ6Oc7lI8/7kDDqcIvyTI6zQ==
   dependencies:
-    "@mux/mux-player-react" "^3.6.0"
+    "@mux/mux-player-react" "^3.8.0"
     cloudflare-video-element "^1.3.4"
-    dash-video-element "^0.2.0"
-    hls-video-element "^1.5.8"
+    dash-video-element "^0.3.0"
+    hls-video-element "^1.5.9"
     spotify-audio-element "^1.0.3"
     tiktok-video-element "^0.1.1"
-    twitch-video-element "^0.1.4"
-    vimeo-video-element "^1.5.5"
-    wistia-video-element "^1.3.4"
-    youtube-video-element "^1.6.2"
+    twitch-video-element "^0.1.5"
+    vimeo-video-element "^1.6.1"
+    wistia-video-element "^1.3.5"
+    youtube-video-element "^1.8.0"
 
 react-social-icons@^6.18.0:
   version "6.18.0"
@@ -3148,10 +3160,10 @@ tslib@^2.4.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
   integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
 
-twitch-video-element@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/twitch-video-element/-/twitch-video-element-0.1.4.tgz#6f7c493c4bb20a04f65990d09c1535b9fe7bda9c"
-  integrity sha512-SDpZ4f7sZmwHF6XG5PF0KWuP18pH/kNG04MhTcpqJby7Lk/D3TS/lCYd+RSg0rIAAVi1LDgSIo1yJs9kmHlhgw==
+twitch-video-element@^0.1.5:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/twitch-video-element/-/twitch-video-element-0.1.6.tgz#986668a6b676b5b42f2abab365014208e2f6edff"
+  integrity sha512-X7l8gy+DEFKJ/EztUwaVnAYwQN9fUJxPkOVJj2sE62sGvGU4DNLyvmOsmVulM+8Plc5dMg6hYIMNRAPaH+39Uw==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -3241,10 +3253,10 @@ util-deprecate@^1.0.2:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-vimeo-video-element@^1.5.5:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/vimeo-video-element/-/vimeo-video-element-1.6.0.tgz#6ec1966cbab7f6dd3ee05c438d7a963c8b325618"
-  integrity sha512-Vs+WWvd6ph6FtY+DqrVO5OHUUS02An87QydUcCUtAsIiXnYhZl0yiDC0XxWiFluo+S6keG38i4xCaQfS1LgeSg==
+vimeo-video-element@^1.6.1:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/vimeo-video-element/-/vimeo-video-element-1.6.3.tgz#ec5c16d0b9bc631af2664c67436f93e0c229d3c9"
+  integrity sha512-pSBMYV+7KbChvtzuXGR3Sg7ZqaAZuTOnHrlZxrauIH2GWMLDnOEK5D0o7yWCcnswtQHVlIz6hXeJYbvQC+gAkw==
   dependencies:
     "@vimeo/player" "2.29.0"
 
@@ -3310,10 +3322,10 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-wistia-video-element@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/wistia-video-element/-/wistia-video-element-1.3.4.tgz#b8b09aaa3869d51489954a5db8b4834b2a114654"
-  integrity sha512-2l22oaQe4jUfi3yvsh2m2oCEgvbqTzaSYx6aJnZAvV5hlMUJlyZheFUnaj0JU2wGlHdVGV7xNY+5KpKu+ruLYA==
+wistia-video-element@^1.3.5:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/wistia-video-element/-/wistia-video-element-1.3.6.tgz#f6e1a8dec5dc2aa533627164d1129f48bb71d804"
+  integrity sha512-wPizIpXDaCs6fvDzhU3MBtEpxIqhgXlu00kSrKgmjPb5DRqZt927xZZjE1qm81Df40d445u4a/mRKX5I66zaYA==
   dependencies:
     super-media-element "~1.4.2"
 
@@ -3355,7 +3367,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-youtube-video-element@^1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/youtube-video-element/-/youtube-video-element-1.6.2.tgz#b5900d733d1d8edb19a9ec188bc524d59eb30eab"
-  integrity sha512-YHDIOAqgRpfl1Ois9HcB8UFtWOxK8KJrV5TXpImj4BKYP1rWT04f/fMM9tQ9SYZlBKukT7NR+9wcI3UpB5BMDQ==
+youtube-video-element@^1.8.0:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/youtube-video-element/-/youtube-video-element-1.8.1.tgz#1fa9a92e5b6d6346bd7ef9f5869a69f9916f00ed"
+  integrity sha512-+5UuAGaj+5AnBf39huLVpy/4dLtR0rmJP1TxOHVZ81bac4ZHFpTtQ4Dz2FAn2GPnfXISezvUEaQoAdFW4hH9Xg==


### PR DESCRIPTION
Address the issue with react-player not loading videos.

- React player breaking change in version 3 was that it no longer uses URL and is now moved to SRC for the video URL.
- Full page video button wasn't pulling in the video and so that has now been fixed by targeting the correct target element.

